### PR TITLE
#163904198 Apply challenge two feedback after demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Install
 
         $ pip install -r requirements.txt
 
+-Export server's secret key by:
+        $ export SECRET_KEY='set-your-secret-key-here'
 
-
-- Run the app by:
+- Run the server by:
 
         $ python manage.py server
 

--- a/app/V1/parties/models.py
+++ b/app/V1/parties/models.py
@@ -56,15 +56,14 @@ class Party:
                 list_party_data.append(item.json_dumps())
                 return list_party_data
 
-    def update_party(self, id, name, hqaddress, logoUrl):
-        """Method to get a party by id"""
-        list_party_data = []
+    @staticmethod
+    def update_party(update_data, id):
+        """ Edit apolitical party """
         for item in all_parties_retrieved:
             if item.id == id:
-                party_to_update = Party(name=name, hqaddress=hqaddress, logoUrl=logoUrl)
-                list_party_data.append(party_to_update.json_dumps())
-                return list_party_data
-            return None
+                item.name = update_data["name"]
+
+        return [{"id": id, "name": update_data["name"]}]
 
     @classmethod
     def delete_party(cls, id):
@@ -72,4 +71,3 @@ class Party:
         for item in all_parties_retrieved:
             if item.id == id:
                 all_parties_retrieved.remove(item)
-

--- a/app/V1/parties/views.py
+++ b/app/V1/parties/views.py
@@ -45,16 +45,6 @@ def post():
             "error": "Post data of type strings"
         }), 400)
 
-    if not Validate.validate_name(name=data["name"]):
-        return make_response(jsonify({
-            "status": 400,
-            "error": "Invalid username"
-        }), 400)
-    if not Validate.validate_name_length(name=data["name"]):
-        return make_response(jsonify({
-            "status": 400,
-            "error": "Name should be atleast 1 character long"
-        }), 400)
     if Party.get_party_by_name(data["name"]):
         return make_response(jsonify({
             "status": 409,
@@ -64,6 +54,23 @@ def post():
     name = data["name"]
     hqaddress = data["hqaddress"]
     logoUrl = data["logoUrl"]
+
+    if Validate.validate_empty_string(data_inputed=name):
+        return make_response(jsonify({
+            "status": 400,
+            "error": "Party name cannot be empty"
+        }), 400)
+    if Validate.validate_empty_string(data_inputed=hqaddress):
+        return make_response(jsonify({
+            "status": 400,
+            "error": "hqaddress cannot be empty"
+        }), 400)
+    if Validate.validate_empty_string(data_inputed=logoUrl):
+        return make_response(jsonify({
+            "status": 400,
+            "error": "logoUrl cannot be empty"
+        }), 400)
+
     new_party = Party(name=name, hqaddress=hqaddress, logoUrl=logoUrl)
     new_party.save()
     return make_response(jsonify({
@@ -104,30 +111,22 @@ def patch(id):
             "error": "Name should be of type strings"
         }), 400)
 
-    if not Validate.validate_name(name=data["name"]):
-        return make_response(jsonify({
-            "status": 400,
-            "error": "Invalid username"
-        }), 400)
-    if not Validate.validate_name_length(name=data["name"]):
-        return make_response(jsonify({
-            "status": 400,
-            "error": "Name should be atleast 1 character long"
-        }), 400)
     if Party.get_party_by_name(data["name"]):
         return make_response(jsonify({
             "status": 409,
             "error": "Party name already taken"
         }), 409)
-
-    name = data["name"]
-    party_to_edit = Party.get_party_by_id(id=id)
-    new_party = Party(name=name, hqaddress=party_to_edit[0]['hqaddress'], logoUrl=party_to_edit[0]['logoUrl'])
-    new_party.update_party(id=None, name=name, hqaddress=party_to_edit[0]['hqaddress'],
-                           logoUrl=party_to_edit[0]['logoUrl'])
+    if Validate.validate_empty_string(data_inputed=data["name"]):
+        return make_response(jsonify({
+            "status": 400,
+            "error": "Party name cannot be empty"
+        }), 400)
+    update_data = request.get_json(force=True)
+    party_to_edit = Party.get_party_by_id(id=id)[0]
+    party_to_edit = Party.update_party(update_data=update_data,id=id)
     return make_response(jsonify({
         "status": 201,
-        "data": new_party.json_dumps()
+        "data": party_to_edit
     }), 201)
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ app.register_blueprint(V1)
 
 @app.errorhandler(405)
 def handle_405_error(e):
+    """Handling 405 error"""
     return jsonify({
         "status": 405,
         "message": "method not allowed"
@@ -23,6 +24,7 @@ def handle_405_error(e):
 
 @app.errorhandler(404)
 def handle_404_error(e):
+    """Handling 404 error"""
     return jsonify({
         "status": 404,
         "message": "Not found"
@@ -31,6 +33,7 @@ def handle_404_error(e):
 
 @app.errorhandler(503)
 def handle_503_error(e):
+    """Handling 503 error"""
     return jsonify({
         "status": 503,
         "message": "Service unavailable"
@@ -39,6 +42,7 @@ def handle_503_error(e):
 
 @app.errorhandler(400)
 def handle_400_error(e):
+    """Handling 400 error"""
     return jsonify({
         "status": 400,
         "message": "Bad request.Please try again"
@@ -47,6 +51,7 @@ def handle_400_error(e):
 
 @app.errorhandler(408)
 def handle_408_error(e):
+    """Handling 408 error"""
     return jsonify({
         "status": 408,
         "message": "Request time out"
@@ -55,6 +60,7 @@ def handle_408_error(e):
 
 @app.errorhandler(429)
 def handle_429_error(e):
+    """Handling 429 error"""
     return jsonify({
         "status": 429,
         "message": "Too Many Requests"

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -1,8 +1,7 @@
 import json
 
 from tests.base_test_case import BaseTestCase
-from utils.helpers import office_to_post, office1_to_post, office2_to_post, office4_to_post, office3_to_post, \
-    office5_to_post, office6_to_post
+from utils.helpers import office_to_post, office1_to_post, office2_to_post, office4_to_post, office3_to_post
 
 
 class TestOffice(BaseTestCase):
@@ -47,20 +46,6 @@ class TestOffice(BaseTestCase):
         """Test posting with office name data of type integer"""
         with self.client:
             response = self.client.post('api/v1/offices', data=json.dumps(office4_to_post),
-                                        headers={'Content-Type': 'application' '/json'})
-            self.assertEqual(response._status_code, 400)
-
-    def test_post_with_short_name(self):
-        """Test posting with a short name"""
-        with self.client:
-            response = self.client.post('api/v1/offices', data=json.dumps(office6_to_post),
-                                        headers={'Content-Type': 'application' '/json'})
-            self.assertEqual(response._status_code, 400)
-
-    def test_post_with_invalid_name(self):
-        """Test posting with a short name"""
-        with self.client:
-            response = self.client.post('api/v1/offices', data=json.dumps(office5_to_post),
                                         headers={'Content-Type': 'application' '/json'})
             self.assertEqual(response._status_code, 400)
 

--- a/tests/test_political_parties.py
+++ b/tests/test_political_parties.py
@@ -1,8 +1,7 @@
 import json
 
 from tests.base_test_case import BaseTestCase
-from utils.helpers import party_to_post, party1_to_post, party2_to_post, party3_to_post, party4_to_post, party5_to_post, \
-    party6_to_post, party7_to_post, party8_to_post
+from utils.helpers import party_to_post, party4_to_post, party5_to_post,party6_to_post, party7_to_post, party8_to_post
 
 
 class TestParties(BaseTestCase):
@@ -15,7 +14,8 @@ class TestParties(BaseTestCase):
             self.assertEqual(response._status_code, 200)
 
     def post_party(self):
-        response = self.client.post(path='api/v1/parties', data=json.dumps(party_to_post), content_type='application/json')
+        response = self.client.post(path='api/v1/parties', data=json.dumps(party_to_post),
+                                    content_type='application/json')
         return response
 
     def test_create_party(self):
@@ -23,27 +23,6 @@ class TestParties(BaseTestCase):
         with self.client:
             response = self.post_party()
             self.assertEqual(response._status_code, 201)
-
-    def test_post_short_name(self):
-        """Test post short name"""
-        with self.client:
-            response = self.client.post('api/v1/parties', data=json.dumps(party1_to_post),
-                                        headers={'Content-Type': 'application' '/json'})
-            self.assertEqual(response._status_code, 400)
-
-    def test_post_invalid_name(self):
-        """Test post invalid name"""
-        with self.client:
-            response = self.client.post('api/v1/parties', data=json.dumps(party2_to_post),
-                                        headers={'Content-Type': 'application' '/json'})
-            self.assertEqual(response._status_code, 400)
-
-    def test_post_invalid_logourl(self):
-        """Test post invalid name"""
-        with self.client:
-            response = self.client.post('api/v1/parties', data=json.dumps(party3_to_post),
-                                        headers={'Content-Type': 'application' '/json'})
-            self.assertEqual(response._status_code, 400)
 
     def test_post_with_no_name(self):
         """Test posting with no name"""
@@ -120,22 +99,6 @@ class TestParties(BaseTestCase):
         with self.client:
             self.post_party()
             response = self.client.patch('api/v1/parties/1/name', data=json.dumps(party7_to_post),
-                                         headers={'Content-Type': 'application' '/json'})
-            self.assertEqual(response._status_code, 400)
-
-    def test_edit_party_with_invalid_name(self):
-        """Tests for editing a political party with no name"""
-        with self.client:
-            self.post_party()
-            response = self.client.patch('api/v1/parties/1/name', data=json.dumps(party3_to_post),
-                                         headers={'Content-Type': 'application' '/json'})
-            self.assertEqual(response._status_code, 400)
-
-    def test_edit_party_with_short_name(self):
-        """Tests for editing a political party with no name"""
-        with self.client:
-            self.post_party()
-            response = self.client.patch('api/v1/parties/1/name', data=json.dumps(party1_to_post),
                                          headers={'Content-Type': 'application' '/json'})
             self.assertEqual(response._status_code, 400)
 

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -82,8 +82,9 @@ office6_to_post = {
     "name": "D"
 }
 
-
 office_to_post8 = {
     "office_type": 1223345,
     "name": "Democrat"
 }
+
+offices_allowed = ["federal", "legislative", "state", "local government"]

--- a/utils/input_validators.py
+++ b/utils/input_validators.py
@@ -1,22 +1,10 @@
-import re
-
-
 class Validate:
     """Class for validating data input"""
-
     @staticmethod
-    def validate_name(name):
-        """method to validate a name"""
-        regex = r"[A-Z][a-zA-Z]"
-        if re.match(regex, name):
+    def validate_empty_string(data_inputed):
+        """Checks if data presented by a user is empty."""
+        if data_inputed.strip() == "":
             return True
         return False
-
-    @staticmethod
-    def validate_name_length(name):
-        """Method to check name should be more than one characters"""
-        if len(name) < 2:
-            return False
-        return True
 
 


### PR DESCRIPTION
### What does this PR do?
Have all the challenge two feed back implemented

### Description of Task to be completed?
- Remove name validation format in when posting an office and a party
- Validate that empty strings cannot be posted
- Validate that only the for given office types are the only ones that can be posted
- Update readme on how to run the app
- Update tests accordingly
- Remove a bug that was present while patching a party

### How should this be manually tested?
* Clone the repo by git clone by : git clone https://github.com/Nduhiu17/politico-server.git
* Navigate into the project by: cd political-server
* Install a virtual environment by: python3.6 -m venv virtual
* Install dependancies by: pip install -r requirements.txt
* Export server's secret key
* Run the server by: python manage.py server
* Hit the following endpoint with postman: http://127.0.0.1:5000/api/v1/offices['POST']
* Hit the following endpoint with postman: http://127.0.0.1:5000/api/v1/parties['POST']
* Hit the following endpoint with postman: http://127.0.0.1:5000/api/v1/parties/<int:id>/name['PATCH']
* Check on the read me

### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163904198

### Screenshots
![screenshot from 2019-02-12 19-49-51](https://user-images.githubusercontent.com/30591881/52653296-c4d04600-2f00-11e9-8f3f-1059be7f1142.png)
![screenshot from 2019-02-12 19-49-05](https://user-images.githubusercontent.com/30591881/52653335-d580bc00-2f00-11e9-83e6-f5493533f7cf.png)
![screenshot from 2019-02-12 19-47-55](https://user-images.githubusercontent.com/30591881/52653404-fb0dc580-2f00-11e9-849f-5c963faff015.png)


